### PR TITLE
Feature/update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@ pinkopy
 =======
 
 [![Build Status](https://travis-ci.org/theherk/pinkopy.svg)](https://travis-ci.org/theherk/pinkopy)
+[![PyPI Version](https://img.shields.io/pypi/v/pinkopy.svg)](https://pypi.python.org/pypi/pinkopy)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/pinkopy.svg)](https://pypi.python.org/pypi/pinkopy)
 
-pinkopy is a Python wrapper for the Commvault api. Of course it does very little initially, but there is no reason to duplicate work across projects.
+pinkopy is a Python wrapper for the Commvault api. Support for Commvault v11 api was added in v2.0.0.
 
 Installation
 ------------
+
+### from PyPI
+
+    pip install pinkopy
+
+### from source
 
     git clone git@github.com:theherk/pinkopy.git
     pip install pinkopy
@@ -23,14 +31,59 @@ config = {
     'pw': 'password'
 }
 
-with CommvaultSession(**config) as s:
-    client_jobs = s.get_jobs('1234', job_filter="Backup")
-    cust_jobs = s.get_subclient_jobs(client_jobs, '12345678', last=3)
+with CommvaultSession(**config) as commvault:
+    client_jobs = commvault.jobs.get_jobs('1234', job_filter="Backup")
+    cust_jobs = commvault.jobs.get_subclient_jobs(client_jobs, '12345678', last=3)
     # multi status
     for job in cust_jobs:
-        job_id = job['jobSummary']['@jobId']
-        job_details = s.get_job_details('1234', job_id)
-        job_vmstatus = s.get_job_vmstatus(job_details)
+        job_id = job['jobSummary']['jobId']
+        job_details = commvault.jobs.get_job_details('1234', job_id)
+        job_vmstatus = commvault.jobs.get_job_vmstatus(job_details)
+```
+
+pinkopy doesn't have to be used as a context manager.
+
+```python
+commvault = CommvaultSession(**config)
+```
+
+pinkopy used to have all the methods on one class. Now, the methods are divided among several classes and are similar to how the api, itself, is laid out. However, the methods that existed when the modularity was introduced, a shim was also introduced to be backwards compatible. So those methods can be called on the CommvaultSession instance directly.
+
+```python
+client_properties = commvault.clients.get_client_properties('2234')
+# or the old way
+client_properties = commvault.get_client_properties('2234')
+```
+
+This way, you old code works. In addition, you can instantiate just the session you need if you prefer.
+
+```python
+with SubclientSession(**config) as subclients:
+    subclients = subclients.get_subclients('2234')
+```
+
+### Cache
+
+The biggest introduction in 2.0.0 was an improved take on caching. Rather than implementing our own ill-conceived cache, we implemented a great [ttl_cache](https://pythonhosted.org/cachetools/#cachetools.func.ttl_cache) that uses [lru_cache](https://docs.python.org/3/library/functools.html#functools.lru_cache) from the core library. It is from a library called [cachetools](https://pythonhosted.org/cachetools/). The implementation allows you to pass in a list of methods you want to use this cache or provides very sensible defaults if you don't.
+
+The cache, for the duration of `cache_ttl`, will respond with the previous return value without running the function. So, for instance, the `get_clients` call could take several seconds on the first call, but only a few milliseconds on following calls.
+
+By default, we cache for 20 minutes, but you can set this value, too.
+
+```python
+cache_methods = ['get_clients', 'get_subclients']
+with CommvaultSession(cache_ttl=120, cache_methods=cache_methods, **config) as commvault:
+    clients1 = commvault.clients.get_clients() # slow
+    clients2 = commvault.clients.get_clients() # fast
+    # ... fast
+```
+
+Or turn off the cache entirely.
+
+```python
+with CommvaultSession(use_cache=False, **config) as commvault:
+    clients1 = commvault.clients.get_clients() # slow
+    clients2 = commvault.clients.get_clients() # slow but fresh
 ```
 
 Contribution

--- a/pinkopy/base_session.py
+++ b/pinkopy/base_session.py
@@ -163,7 +163,12 @@ class BaseSession(object):
             raise PinkopyError(msg)
 
     def get_token(self):
-        """Login to Commvault and get token."""
+        """Login to Commvault and get token.
+
+        Returns:
+            str: token
+                Also, sets Authtoken in default headers.
+        """
         path = 'Login'
         payload = {
             'DM2ContentIndexing_CheckCredentialReq': {

--- a/pinkopy/base_session.py
+++ b/pinkopy/base_session.py
@@ -152,7 +152,7 @@ class BaseSession(object):
             elif res.status_code != 200:
                 res.raise_for_status()
             else:
-                log.info('CMDBSession made request to {0}'.format(url))
+                log.info('request: {} {}'.format(method, url))
                 return res
         except requests.exceptions.HTTPError as err:
             log.error(err)

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,12 @@
 from setuptools import setup, find_packages
 import sys
 
-
-with open('README.md') as f:
-    readme = f.read()
+try:
+    import pypandoc
+    readme = pypandoc.convert('README.md', 'rst')
+except(IOError, ImportError):
+    with open('README.md') as f:
+        readme = f.read()
 
 install_requires = [
     'cachetools>=1.1.5',


### PR DESCRIPTION
Change documentation to prepare for release 2.0.0.  Major point release is not due to the massive change in the code organization, but by one call with one less argument. `get_job_details` now only requires the job id. Before this required a client id, but that was superfluous, and was removed.

Although some efforts were made to make this version as backward compatible as possible, this change represents a change to the api that is breaking, and therefore must be a major point.

However, although the modules can be accessed on the new subsessions, there is a shim on the CommvaultSession that allows all calls to be made using the previous method, directly on this session. Also, while some arguments could be strings or integers before, these will now generate a log message that this has been deprecated and should, in the future, use strings... but they still work.
